### PR TITLE
Fix migration path for PostgreSQL compatbility

### DIFF
--- a/db/migrate/20110125200118_add_uniqueness_index_to_people.rb
+++ b/db/migrate/20110125200118_add_uniqueness_index_to_people.rb
@@ -2,15 +2,11 @@ class AddUniquenessIndexToPeople < ActiveRecord::Migration
   def self.up
     remove_index :people, [:user_id, :project_id]
     Person.connection.execute <<-EOF
-      DELETE #{Person.table_name}
-      FROM #{Person.table_name}
-      LEFT OUTER JOIN (
-         SELECT MIN(id) as id, user_id, project_id
-         FROM #{Person.table_name}
-         GROUP BY user_id, project_id) as KeepRows ON
-         #{Person.table_name}.id = KeepRows.id
-      WHERE
-         KeepRows.id IS NULL
+      DELETE FROM #{Person.table_name}
+      WHERE id NOT IN
+        (SELECT id FROM (SELECT MIN(id) as id, user_id, project_id
+          FROM #{Person.table_name}
+          GROUP BY user_id, project_id) KeepRows)
     EOF
     add_index :people, [:user_id, :project_id], :unique => true
   end


### PR DESCRIPTION
While setting up a new installation, a bit absent-minded I just `rake db:migrate`d from scratch instead of loading the schema.
Then it failed with a migration whose syntax wasn't compatible to PostgreSQL so I fixed it.
