### PR TITLE
Fix user migration

### DIFF
--- a/db/migrate/20100429210031_initial_schema.rb
+++ b/db/migrate/20100429210031_initial_schema.rb
@@ -291,7 +291,7 @@ class InitialSchema < ActiveRecord::Migration
       t.string   "login",                       :limit => 40
       t.string   "first_name",                  :limit => 20,  :default => ""
       t.string   "last_name",                   :limit => 20,  :default => ""
-      t.text     "biography",                                  :default => "", :null => false
+      t.text     "biography"
       t.string   "email",                       :limit => 100
       t.string   "crypted_password",            :limit => 40
       t.string   "salt",                        :limit => 40

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(:version => 20140209164838) do
     t.string   "login",                     :limit => 40
     t.string   "first_name",                :limit => 20,  :default => ""
     t.string   "last_name",                 :limit => 20,  :default => ""
-    t.text     "biography",                                :default => ""
+    t.text     "biography"
     t.string   "email",                     :limit => 100
     t.string   "crypted_password",          :limit => 40
     t.string   "salt",                      :limit => 40


### PR DESCRIPTION
I encountered the following error running migration with mysql...
What do you thing about removing the default value in the users.biography field?

```
Mysql2::Error: BLOB/TEXT column 'biography' can't have a default value: 
CREATE TABLE `users` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY, `login` varchar(40), `first_name` varchar(20) DEFAULT '', `last_name` varchar(20) DEFAULT '', `biography` text DEFAULT '' NOT NULL, `email` varchar(100), `crypted_password` varchar(40), `salt` varchar(40), `remember_token` varchar(40), `remember_token_expires_at` datetime, `time_zone` varchar(255) DEFAULT 'Eastern Time (US & Canada)', `language` varchar(255) DEFAULT 'en', `first_day_of_week` varchar(255) DEFAULT 'sunday', `invitations_count` int(11) DEFAULT 0 NOT NULL, `login_token` varchar(40), `login_token_expires_at` datetime, `welcome` tinyint(1) DEFAULT 0, `confirmed_user` tinyint(1) DEFAULT 0, `last_read_announcement` int(11), `deleted_at` datetime, `rss_token` varchar(40), `admin` tinyint(1) DEFAULT 0, `comments_count` int(11) DEFAULT 0 NOT NULL, `notify_mentions` tinyint(1) DEFAULT 1, `notify_conversations` tinyint(1) DEFAULT 1, `notify_task_lists` tinyint(1) DEFAULT 1, `notify_tasks` tinyint(1) DEFAULT 1, `avatar_file_name` varchar(255), `avatar_content_type` varchar(255), `avatar_file_size` int(11), `invited_by_id` int(11), `invited_count` int(11) DEFAULT 0 NOT NULL, `created_at` datetime, `updated_at` datetime, `wants_task_reminder` tinyint(1) DEFAULT 1, `recent_projects_ids` text, `feature_level` varchar(255) DEFAULT '', `spreedly_token` varchar(255) DEFAULT '') ENGINE=InnoDB
```

```
```
