### PR TITLE
mobile login now displays Username and Password fields

### DIFF
--- a/app/views/sessions/new.m.haml
+++ b/app/views/sessions/new.m.haml
@@ -1,6 +1,6 @@
 %h2= t('.title')
 
-- form_tag session_path, :class => 'new_session', :id => 'new_session' do
+= form_tag session_path, :class => 'new_session', :id => 'new_session' do
   - if flash[:error]
     %p.error= flash[:error]
   = render 'sessions/fields'


### PR DESCRIPTION
I reordered my branches as I was suggested by Crewmate's admin in order to only include the significant change I made. 
