### PR TITLE
Fix for Task assignee messed up #103

### DIFF
--- a/app/javascripts/task.js
+++ b/app/javascripts/task.js
@@ -49,11 +49,11 @@ document.on('click', '.date_picker', function(e, element) {
 })
 
 Task = {
-  
+
   sortableChange: function(draggable) {
     this.currentDraggable = draggable
   },
-  
+
   sortableUpdate: function() {
     var taskId = this.currentDraggable.readAttribute('data-task-id'),
         taskList = this.currentDraggable.up('.task_list')
@@ -190,6 +190,5 @@ document.on('ajax:success', 'form.edit_task', function(e, form) {
       task_count -= 1
   }
   $('open_my_tasks').update(task_count)
-
 })
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -81,7 +81,7 @@ class Person < ActiveRecord::Base
     project_ids = Array.wrap(projects).map(&:id)
     current_user_id = current_user.try(:id).to_i
 
-    select("people.project_id, people.user_id, users.login, users.first_name, users.last_name, people.id, users.id")
+    select("people.id, people.project_id, people.user_id, users.login, users.first_name, users.last_name")
       .joins(:project).joins(:user)
       .where("people.project_id IN (?) AND (people.deleted IS NULL OR people.deleted = ?)", project_ids, false)
       .order("users.id = #{current_user_id} DESC, users.login")

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -55,30 +55,34 @@ describe Person do
       user_names.size.should eql 2
     end
 
-    it 'should contain user1' do
-      user_names.map(&:user_id).should include(user1.id)
-    end
-
-    it 'should contain user3' do
-      user_names.map(&:user_id).should include(user3.id)
+    it 'should contain user1 and user3' do
+      user_names.map(&:user_id).should include(user1.id, user3.id)
     end
 
     it 'should not contain user2' do
-      user_names.map(&:user_id).should_not include(user2.id)
+      user_names.map(&:user_id).should_not include user2.id
     end
 
     it 'should contain project1' do
-      user_names.map(&:project_id).should include(project1.id)
+      user_names.map(&:project_id).should include project1.id
     end
 
     it 'should not contain project2' do
-      user_names.map(&:project_id).should_not include(project2.id)
+      user_names.map(&:project_id).should_not include project2.id
+    end
+
+    its 'ids should not include project2\' ids' do
+      user_names.map(&:id).should_not include Person.user_names_from_projects(project2).map(&:id)
+    end
+
+    it 'should not contain project2' do
+      user_names.map(&:project_id).should_not include project2.id
     end
 
     context 'his first result' do
       subject(:user_name) { user_names.first }
-
-      it { should respond_to(:project_id, :login, :first_name, :last_name, :user_id) }
+      it { should respond_to(:project_id, :login, :first_name, :last_name, :user_id, :id) }
     end
+
   end
 end


### PR DESCRIPTION
The issue was caused by a wrong query select in the `Person.users_from_projects` method

```
select("people.project_id, people.user_id, users.login, users.first_name, users.last_name, people.id, users.id")
```

The double declaration people.id, users.id caused the override of people.id with users.id
