### PR TITLE
Changing teambox to crewmate in URLs and stories

### DIFF
--- a/features/activity_show_more.feature
+++ b/features/activity_show_more.feature
@@ -4,7 +4,7 @@ Feature: Show more comment on activity pages
   Background:
   Given a project with users @balint, @pablo, @charles, @jordi and @james
   Given I am logged in as @charles
-  And I am in the project called "Teambox" the following comments:
+  And I am in the project called "Crewmate" the following comments:
     | body                                        | conversation                   |
     | I read a lot of good stuff about it         | What do you think about redis  |
     | Should we do A/B testing?                   | Should we use A/B testing      |
@@ -16,7 +16,7 @@ Feature: Show more comment on activity pages
     | Let's go with bingo, look simpler           | Should we use A/B testing      |
     | I did benchmark vs memcached, quite similar.| What do you think about redis  |
     | Its almost done.                            | Should we use A/B testing      |
-  And 10 comments are created in the project "Teambox"
+  And 10 comments are created in the project "Crewmate"
 
   Scenario: Show more with mixed threads
     When I go to the projects page
@@ -26,7 +26,7 @@ Feature: Show more comment on activity pages
 
   Scenario: Show more with new comment in visible thread
     When I go to the projects page
-    And 10 comments are created in the project "Teambox"
+    And 10 comments are created in the project "Crewmate"
     And I follow "Show more"
     Then I should see "What do you think about redis" only once
     And I should see "Should we use A/B testing" only once

--- a/features/comment_create.feature
+++ b/features/comment_create.feature
@@ -32,5 +32,5 @@ Feature: Posting a comment on a project wall
     When I fill in the comment box with underscored words and links
     And I wait for 1 second
     Then I should see "<em>Text</em> with an underscored_long_word" in the preview
-    And I should see "http://teambox.com" in the preview
-    And I should see "jordi@teambox.com" in the preview
+    And I should see "http://crewmate.org" in the preview
+    And I should see "jordi@crewmate.org" in the preview

--- a/features/comment_mentions.feature
+++ b/features/comment_mentions.feature
@@ -1,6 +1,6 @@
 Feature: Notifications of comment mentions
   In order to not miss any of the discussions important to me
-  As a Teambox user
+  As a Crewmate user
   I want to be notified when I'm mentioned
 
   Background: 

--- a/features/community_mode.feature
+++ b/features/community_mode.feature
@@ -1,5 +1,5 @@
 @organizations
-Feature: When I use Teambox community version, there is only one organization
+Feature: When I use Crewmate community version, there is only one organization
 
   Background:
     Given I am using the community version
@@ -26,7 +26,7 @@ Feature: When I use Teambox community version, there is only one organization
     And "mislav@fuckingawesome.com" should receive an email
     When I open the email
     Then I should see "Hey, Mislav Marohnić!" in the email body
-    When I follow "Log into Teambox now!" in the email
+    When I follow "Log into Crewmate now!" in the email
     Then I should see "Welcome"
 
   Scenario: I create a user account, but without an organization the system is not fully configured
@@ -49,7 +49,7 @@ Feature: When I use Teambox community version, there is only one organization
     And "mislav" sent an invitation to "ed_bloom@spectre.com" for the project "Ruby Rockstars"
     And I log out
     When "ed_bloom@spectre.com" opens the email with subject "Ruby Rockstars"
-    And they should see "Mislav Marohnić wants to collaborate with you on Teambox" in the email body
+    And they should see "Mislav Marohnić wants to collaborate with you on Crewmate" in the email body
     And I should see "Ruby Rockstars" in the email body
     And I follow "Accept the invitation to start collaborating" in the email
     When I fill in "Username" with "bigfish"

--- a/features/conversation_convert_to_task.feature
+++ b/features/conversation_convert_to_task.feature
@@ -69,16 +69,16 @@ Feature: Converting a conversation to a task
   Scenario: Converting a simple conversation on the overview page and specifying additional task attributes
     Given the following confirmed users exist
     | login  | email                    | first_name | last_name |
-    | pablos | pablo@teambox.com        | Pablo      | Villalba  |
-    | saimon | saimon@teambox.com       | Saimon     | Moore     |
-    And I am in the project called "Teambox"
-    And all the users are in the project with name: "Teambox"
+    | pablos | pablo@crewmate.org        | Pablo      | Villalba  |
+    | saimon | saimon@crewmate.org       | Saimon     | Moore     |
+    And I am in the project called "Crewmate"
+    And all the users are in the project with name: "Crewmate"
     And the following task lists with associations exist:
       | name         | project |
-      | Next release | Teambox |
-      | Bugfixes     | Teambox |
-    Given I started a simple conversation in the "Teambox" project
-    When I go to the page of the "Teambox" project
+      | Next release | Crewmate |
+      | Bugfixes     | Crewmate |
+    Given I started a simple conversation in the "Crewmate" project
+    When I go to the page of the "Crewmate" project
     And I click the conversation's comment box
     And I follow "Convert to task"
     And I wait for 2 seconds

--- a/features/organization_invitations.feature
+++ b/features/organization_invitations.feature
@@ -5,8 +5,8 @@ Feature: Joining organizations
     Given @mislav exists and is logged in
     And the following confirmed users exist
       | login  | email                    | first_name | last_name |
-      | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
-      | jordi  | jordi@teambox.com        | Jordi      | Romero    |
+      | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
+      | jordi  | jordi@crewmate.org        | Jordi      | Romero    |
     And I am currently in the project ruby_rockstars
     And I am an administrator in the organization called "ACME"
     And "pablo" is a participant in the organization called "ACME"
@@ -44,7 +44,7 @@ Feature: Joining organizations
     And I select "Admin. Can invite users to the project, and delete comments." from "invitation_role"
     And I select "Don't invite. User won't be able to create projects in this organization." from "invitation_membership"
     And I press "Invite"
-    When "jordi" accepts the invitation from "jordi@teambox.com"
+    When "jordi" accepts the invitation from "jordi@crewmate.org"
     Then "jordi" should not belong to the organization "ACME"
     And "jordi" should belong to the project "Ruby Rockstars" as an admin
 
@@ -53,7 +53,7 @@ Feature: Joining organizations
     And I select "Admin. Can invite users to the project, and delete comments." from "invitation_role"
     And I select "As a participant. Will be able to create his own projects." from "invitation_membership"
     And I press "Invite"
-    When "jordi" accepts the invitation from "jordi@teambox.com"
+    When "jordi" accepts the invitation from "jordi@crewmate.org"
     Then "jordi" should belong to the organization "ACME" as a participant
     And "jordi" should belong to the project "Ruby Rockstars" as an admin
 
@@ -62,7 +62,7 @@ Feature: Joining organizations
     And I select "Admin. Can invite users to the project, and delete comments." from "invitation_role"
     And I select "As an administrator. Will be able to add new users and manage the organization." from "invitation_membership"
     And I press "Invite"
-    When "jordi" accepts the invitation from "jordi@teambox.com"
+    When "jordi" accepts the invitation from "jordi@crewmate.org"
     Then "jordi" should belong to the organization "ACME" as a admin
     And "jordi" should belong to the project "Ruby Rockstars" as an admin
 

--- a/features/organization_manage.feature
+++ b/features/organization_manage.feature
@@ -4,8 +4,8 @@ Feature: Managing organizations
   Background: 
     Given the following confirmed users exist
       | login  | email                    | first_name | last_name |
-      | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
-      | jordi  | jordi@teambox.com        | Jordi      | Romero    |
+      | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
+      | jordi  | jordi@crewmate.org        | Jordi      | Romero    |
     And @mislav exists and is logged in
     And I am currently in the project ruby_rockstars
     And "jordi" is in the project called "Ruby Rockstars"

--- a/features/organization_site.feature
+++ b/features/organization_site.feature
@@ -5,7 +5,7 @@ Feature: Public sites for organizations. Allow to view an entrance page and log 
     Given @mislav exists and is logged in
     And the following confirmed users exist
       | login  | email                    | first_name | last_name |
-      | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+      | pablo  | pablo@crewmate.com        | Pablo      | Villalba  |
     And I am currently in the project ruby_rockstars
     And "pablo" is in the project called "Ruby Rockstars"
     And I am an administrator in the organization called "ACME"

--- a/features/project_invitations.feature
+++ b/features/project_invitations.feature
@@ -5,8 +5,8 @@ Feature: Invite a user to a project
     Given an organization exists with name: "ACME"
     And a project exists with name: "Ruby Rockstars"
     And the project "Ruby Rockstars" belongs to "ACME" organization
-    And a confirmed user exists with login: "mislav", first_name: "Mislav", last_name: "Marohnić", email: "mislav@teambox.com"
-    And a confirmed user exists with login: "pablo", first_name: "Pablo", last_name: "Villalba", email: "pablo@teambox.com"
+    And a confirmed user exists with login: "mislav", first_name: "Mislav", last_name: "Marohnić", email: "mislav@crewmate.org"
+    And a confirmed user exists with login: "pablo", first_name: "Pablo", last_name: "Villalba", email: "pablo@crewmate.org"
     And "mislav" is the owner of the project "Ruby Rockstars"
     And "mislav" is an administrator in the organization called "ACME"
     And "pablo" is a participant in the organization called "ACME"
@@ -42,7 +42,7 @@ Feature: Invite a user to a project
   Scenario: User creates account and joins project from invitation
     Given "mislav" sent an invitation to "ed_bloom@spectre.com" for the project "Ruby Rockstars"
     When "ed_bloom@spectre.com" opens the email with subject "Ruby Rockstars"
-    And they should see "Mislav Marohnić wants to collaborate with you on Teambox" in the email body
+    And they should see "Mislav Marohnić wants to collaborate with you on Crewmate" in the email body
     And I should see "Ruby Rockstars" in the email body
     And I follow "Accept the invitation to start collaborating" in the email
     When I fill in "Username" with "bigfish"
@@ -59,25 +59,25 @@ Feature: Invite a user to a project
 
   Scenario: Mislav is invited to a project by someone else
     Given I am logged in as @mislav
-    And there is a project called "Teambox Roulette"
-    When I go to the page of the "Teambox Roulette" project
+    And there is a project called "Crewmate Roulette"
+    When I go to the page of the "Crewmate Roulette" project
     Then I should see the unauthorized private project message
-    Given the owner of the project "Teambox Roulette" sent an invitation to "mislav"
-    When I go to the page of the "Teambox Roulette" project
+    Given the owner of the project "Crewmate Roulette" sent an invitation to "mislav"
+    When I go to the page of the "Crewmate Roulette" project
     And I press "Accept"
-    Then I should see "Teambox Roulette"
+    Then I should see "Crewmate Roulette"
 
   Scenario: Mislav invites a user who belongs to the project's organization
     Given I am logged in as @mislav
     When I go to the people page of the "Ruby Rockstars" project
     And I fill in "invitation_user_or_email" with "pablo"
     And I press "Invite"
-    Then "pablo@teambox.com" should receive an email
-    When "pablo@teambox.com" opens the email
+    Then "pablo@crewmate.org" should receive an email
+    When "pablo@crewmate.org" opens the email
     Then I should see "You are now a member of the project" in the email body
     And I should see "Ruby Rockstars" in the email body
 
-  Scenario: Mislav invites existing teambox users to a project
+  Scenario: Mislav invites existing crewmate users to a project
 
   Scenario: Mislav leaves a project
 
@@ -86,9 +86,9 @@ Feature: Invite a user to a project
   Scenario: Mislav deletes an invitation that hasnt been accepted
     Given I am logged in as @mislav
     When I go to the people page of the "Ruby Rockstars" project
-    And I fill in "invitation_user_or_email" with "charles@teambox.com"
+    And I fill in "invitation_user_or_email" with "charles@crewmate.org"
     And I press "Invite"
     And I follow "Discard invitation"
     And I wait for 1 second
-    Then I should not see "charles@teambox.com"
+    Then I should not see "charles@crewmate.org"
 

--- a/features/project_join.feature
+++ b/features/project_join.feature
@@ -5,7 +5,7 @@ Background:
   Given @mislav exists and is logged in
   And the following confirmed users exist
     | login  | email                    | first_name | last_name |
-    | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+    | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
   And I am currently in the project ruby_rockstars
   And I am an administrator in the organization called "ACME"
 

--- a/features/project_leave.feature
+++ b/features/project_leave.feature
@@ -4,7 +4,7 @@ Feature: Leaving a project
   Background:
     Given the following confirmed users exist
       | login  | email                    | first_name | last_name |
-      | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+      | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
     Given @mislav exists and is logged in
     And I am currently in the project ruby_rockstars
     And "pablo" is in the project called "Ruby Rockstars"

--- a/features/project_public.feature
+++ b/features/project_public.feature
@@ -15,4 +15,4 @@ Feature: Public projects
     And I should see "Other public projects..."
     When I follow "All Conversations"
     Then I should see "Conversations in this community"
-    And I should see "+ Log into Teambox to create a new conversation"
+    And I should see "+ Log into Crewmate to create a new conversation"

--- a/features/project_transfer.feature
+++ b/features/project_transfer.feature
@@ -4,7 +4,7 @@ Feature: Transfer Project
     Given the following confirmed users exist
       | login  | email                    | first_name | last_name |
       | balint | balint.erdi@gmail.com    | Balint     | Erdi      |
-      | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+      | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
       | james  | james.urquhart@gmail.com | James      | Urquhart  |
     Given @mislav exists and is logged in
     And I am currently in the project ruby_rockstars

--- a/features/search_projects.feature
+++ b/features/search_projects.feature
@@ -1,7 +1,7 @@
 @sphinx @no-txn @javascript
 Feature: Search comments in projects
   In order to discover what has been said about a subject
-  As a Teambox user
+  As a Crewmate user
   I want to search for keywords
 
   Background: 

--- a/features/step_definitions/comment_steps.rb
+++ b/features/step_definitions/comment_steps.rb
@@ -11,6 +11,6 @@ When /^I fill in the comment box with line breaks$/ do
 end
 
 When /^I fill in the comment box with underscored words and links$/ do
-  text = "_Text_ with an underscored_long_word and a link:\nhttp://teambox.com or an email: jordi@teambox.com"
+  text = "_Text_ with an underscored_long_word and a link:\nhttp://crewmate.org or an email: jordi@crewmate.org"
   find(:xpath, '//textarea[contains(@name, \'[body]\')]').set(text)
 end

--- a/features/task_archived.feature
+++ b/features/task_archived.feature
@@ -1,24 +1,24 @@
 @javascript @tasks
 Feature: Show archived tasks in task lists
   In order to cut down on page load time
-  As a Teambox developer
+  As a Crewmate developer
   I want users to see archived tasks in task lists quickly and easily
 
   Background: 
-    Given a project exists with name: "Market Teambox"
+    Given a project exists with name: "Market Crewmate"
     And a confirmed user exists with login: "balint"
-    And "balint" is in the project called "Market Teambox"
+    And "balint" is in the project called "Market Crewmate"
     And a task list exists with name: "This week"
-    And the task list called "This week" belongs to the project called "Market Teambox"
+    And the task list called "This week" belongs to the project called "Market Crewmate"
     And the following tasks with associations exist:
       | name                   | task_list | project        |
-      | Tell my friends        | This week | Market Teambox |
-      | Tell the tech bloggers | This week | Market Teambox |
+      | Tell my friends        | This week | Market Crewmate |
+      | Tell the tech bloggers | This week | Market Crewmate |
     And the task called "Tell my friends" is resolved
     And I am logged in as @balint
 
   Scenario: See archived tasks
-    When I go to the "Market Teambox" tasks page
+    When I go to the "Market Crewmate" tasks page
     Then I should see the task called "Tell the tech bloggers" in the "This week" task list
     But I should not see the task called "Tell my friends" in the "This week" task list
     When I follow "Show 1 archived task" in the "This week" task list
@@ -30,10 +30,10 @@ Feature: Show archived tasks in task lists
 
   Scenario: No archived tasks in a task list
     Given a task list exists with name: "Next month"
-    And the task list called "Next month" belongs to the project called "Market Teambox"
+    And the task list called "Next month" belongs to the project called "Market Crewmate"
     And the following tasks with associations exists:
       | name                         | task_list  | project        |
-      | Post on Digg and Hacker News | Next month | Market Teambox |
-    When I go to the "Market Teambox" tasks page
+      | Post on Digg and Hacker News | Next month | Market Crewmate |
+    When I go to the "Market Crewmate" tasks page
     Then I should not see a "Show 0 archived tasks" link in the "Next month" task list
 

--- a/features/task_comment.feature
+++ b/features/task_comment.feature
@@ -3,12 +3,12 @@ Feature: Commenting on a task
 
   Background:
     Given @mislav exists and is logged in
-    And I am in the project called "Teambox"
-    And the task list called "This week" belongs to the project called "Teambox"
+    And I am in the project called "Crewmate"
+    And the task list called "This week" belongs to the project called "Crewmate"
     And the following task with associations exist:
       | name                         | task_list      | project |
-      | Setup Continious integration | This week      | Teambox |
-    And I go to the "teambox" tasks page
+      | Setup Continious integration | This week      | Crewmate |
+    And I go to the "crewmate" tasks page
 
   Scenario: I change task date by commenting
     When I follow "Setup Continious integration"

--- a/features/task_edit.feature
+++ b/features/task_edit.feature
@@ -3,12 +3,12 @@ Feature: Editing a task
 
   Background:
     Given @charles exists and is logged in
-    And I am in the project called "Teambox"
-    And the task list called "Bugs" belongs to the project called "Teambox"
+    And I am in the project called "Crewmate"
+    And the task list called "Bugs" belongs to the project called "Crewmate"
     And the following task with associations exist:
       | name          | task_list | project |
-      | Fix major bug | Bugs      | Teambox |
-    And I go to the "Teambox" tasks page
+      | Fix major bug | Bugs      | Crewmate |
+    And I go to the "Crewmate" tasks page
 
   Scenario: I change task name from full view
     When I follow "Fix major bug"

--- a/features/task_list_reorder.feature
+++ b/features/task_list_reorder.feature
@@ -3,12 +3,12 @@ Feature: Reorder task within the task list view
 
   Background:
     Given @mislav exists and is logged in
-    And I am in the project called "Teambox"
+    And I am in the project called "Crewmate"
     And the following task lists with associations exist:
       | name         | project |
-      | Bugfixes     | Teambox |
-      | Next release | Teambox |
-    And I go to the "teambox" tasks page
+      | Bugfixes     | Crewmate |
+      | Next release | Crewmate |
+    And I go to the "crewmate" tasks page
 
   Scenario: Reorder task list
     When I follow "Reorder Task Lists"

--- a/features/task_lists_view.feature
+++ b/features/task_lists_view.feature
@@ -3,15 +3,15 @@ Feature: List tasks in project broken down by task list
 
   Background: 
     Given @mislav exists and is logged in
-    And I am in the project called "teambox"
+    And I am in the project called "crewmate"
 
   Scenario: Task list index
-    Given the task list called "urgent" belongs to the project called "teambox"
+    Given the task list called "urgent" belongs to the project called "crewmate"
     And the task called "fix big problem" belongs to the task list called "urgent"
     And the task called "fix big problem" is open
     And the task called "daily reminder email" belongs to the task list called "urgent"
     And the task called "daily reminder email" is resolved
-    When I go to the "teambox" tasks page
+    When I go to the "crewmate" tasks page
     Then I should see "fix big problem"
     But I should not see "daily reminder email"
 

--- a/features/task_reorder.feature
+++ b/features/task_reorder.feature
@@ -3,18 +3,18 @@ Feature: Reorder task within the task list view
 
   Background:
     Given @mislav exists and is logged in
-    And I am in the project called "Teambox"
+    And I am in the project called "Crewmate"
     And the following task lists with associations exist:
       | name      | project |
-      | This week | Teambox |
-      | Next week | Teambox |
+      | This week | Crewmate |
+      | Next week | Crewmate |
     And the following tasks with associations exist:
       | name                    | task_list | project |
-      | Write more test         | This week | Teambox |
-      | Fix a drag and drop bug | This week | Teambox |
-      | Write a blog post       | Next week | Teambox |
-      | Publish a gem           | Next week | Teambox |
-    And I go to the "teambox" tasks page
+      | Write more test         | This week | Crewmate |
+      | Fix a drag and drop bug | This week | Crewmate |
+      | Write a blog post       | Next week | Crewmate |
+      | Publish a gem           | Next week | Crewmate |
+    And I go to the "crewmate" tasks page
 
   Scenario: Reorder task within a task list
     When I follow "This week"

--- a/features/task_views.feature
+++ b/features/task_views.feature
@@ -1,24 +1,24 @@
 @javascript @tasks
 Feature: See tasks in different, common groupings
   In order to see just the tasks the user needs and quickly
-  As a Teambox developer
+  As a Crewmate developer
   I want to give options to see tasks in different groupings
 
   Background: 
-    Given a project exists with name: "Market Teambox"
+    Given a project exists with name: "Market Crewmate"
     And a confirmed user exists with login: "balint"
     And I am logged in as @balint
-    And "balint" is in the project called "Market Teambox"
+    And "balint" is in the project called "Market Crewmate"
     And the following task lists with associations exist:
       | name      | project        |
-      | This week | Market Teambox |
-      | Later     | Market Teambox |
+      | This week | Market Crewmate |
+      | Later     | Market Crewmate |
     And the following tasks with associations exist:
       | name                                   | task_list | project        |
-      | Tell my friends                        | This week | Market Teambox |
-      | Tell the tech bloggers                 | This week | Market Teambox |
-      | Post on Digg and Hacker News           | This week | Market Teambox |
-      | Beg Apple to approve of the iPhone app | Later     | Market Teambox |
+      | Tell my friends                        | This week | Market Crewmate |
+      | Tell the tech bloggers                 | This week | Market Crewmate |
+      | Post on Digg and Hacker News           | This week | Market Crewmate |
+      | Beg Apple to approve of the iPhone app | Later     | Market Crewmate |
 
   Scenario: See all the tasks
     Given the task called "Tell my friends" is resolved
@@ -26,7 +26,7 @@ Feature: See tasks in different, common groupings
     And the task called "Tell the tech bloggers" is open
     And the task called "Post on Digg and Hacker News" is hold
     And the task called "Beg Apple to approve of the iPhone app" is rejected
-    When I go to the "Market Teambox" tasks page
+    When I go to the "Market Crewmate" tasks page
     Then I should see the following tasks:
       | task_list_name | task_name                    |
       | This week      | Tell the tech bloggers       |
@@ -39,7 +39,7 @@ Feature: See tasks in different, common groupings
     And the task called "Tell my friends" is resolved
     And the task called "Post on Digg and Hacker News" is assigned to me
     And the task called "Post on Digg and Hacker News" is open
-    When I go to the "Market Teambox" tasks page
+    When I go to the "Market Crewmate" tasks page
     And I select "My tasks (1)" from "filter_assigned"
     And I wait for .2 seconds
     Then I should see the following tasks:
@@ -61,7 +61,7 @@ Feature: See tasks in different, common groupings
   Scenario: See archived tasks
     Given the task called "Tell my friends" is resolved
     And the task called "Post on Digg and Hacker News" is resolved
-    When I go to the "Market Teambox" tasks page
+    When I go to the "Market Crewmate" tasks page
     And I follow "Show 2 archived tasks"
     And I wait for .3 seconds
     Then I should see the following tasks:

--- a/features/tasks_due.feature
+++ b/features/tasks_due.feature
@@ -3,17 +3,17 @@ Feature: Showing tasks
 
   Background:
     Given @charles exists and is logged in
-    And I am in the project called "Teambox"
-    And the task list called "Bugs" belongs to the project called "Teambox"
+    And I am in the project called "Crewmate"
+    And the task list called "Bugs" belongs to the project called "Crewmate"
     And the following task with associations exist:
       | name          | task_list | project |
-      | Fix major bug | Bugs      | Teambox |
+      | Fix major bug | Bugs      | Crewmate |
     And the task called "Fix major bug" is due today
     And the task called "Fax Major" is assigned to "charles"
 
   Scenario: I timewarp to the future and see my task is now late
     Given @charles has his time zone set to Madrid
     And utc time is now 1 hour and a bit before midnight
-    And I go to the "Teambox" tasks page
+    And I go to the "Crewmate" tasks page
     Then I should see "1 days late"
     And time is flowing normally again

--- a/features/teamboxdata_import.feature
+++ b/features/teamboxdata_import.feature
@@ -5,18 +5,18 @@ Background:
   And @mislav exists and is logged in
   And I am in the project called "Ruby Rockstars"
   And I am an administrator in the organization of the project called "Ruby Rockstars"
-  And the organization of the project called "Ruby Rockstars" is called "Teambox Data"
+  And the organization of the project called "Ruby Rockstars" is called "Crewmate Data"
   And deferred data processing is off
 
 Scenario: Mislav imports an historic project
   When I go to the your data page
   And the following confirmed users exist
     | login  | email                    | first_name | last_name |
-    | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+    | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
     | frodo  | frodo@theshire.com       | Frodo      | Baggins   |
     | gandalf| gandalf@middleearth.com  | Gandalf    | Grey      |
   And I follow "Import"
-  And I choose "Teambox"
+  And I choose "Crewmate"
   And I attach the file "spec/fixtures/teamboxdump.json" to "teambox_data_import_data"
   And I press "Import data"
   Then I should see "Andrew Wiggin (@gandhi_1)"
@@ -28,10 +28,10 @@ Scenario: Mislav imports an historic project
     | Andrew Wiggin (@gandhi_2)             |  Mislav Marohnić (@mislav) |
     | Andrew Wiggin (@gandhi_3)             |  Mislav Marohnić (@mislav) |
     | Andrew Wiggin (@gandhi_4)             |  Mislav Marohnić (@mislav) |
-    | Put all projects in this organization | Teambox Data               |
+    | Put all projects in this organization | Crewmate Data               |
   And I press "Import"
   Then I should see "Imported projects"
-  And I should see "Teambox #1"
+  And I should see "Crewmate #1"
   And @mislav should receive 1 email
   And @pablo should receive no emails
   And @frodo should receive no emails
@@ -42,14 +42,14 @@ Scenario: Mislav imports another historic project
   When I go to the your data page
   And the following confirmed users exist
     | login  | email                    | first_name | last_name |
-    | pablo  | pablo@teambox.com        | Pablo      | Villalba  |
+    | pablo  | pablo@crewmate.org        | Pablo      | Villalba  |
     | frodo  | frodo@theshire.com       | Frodo      | Baggins   |
     | gandalf| gandalf@middleearth.com  | Gandalf    | Grey      |
   And "pablo" is an administrator in the organization of the project called "Ruby Rockstars"
   And "gandalf" is an administrator in the organization of the project called "Ruby Rockstars"
   And "frodo" is an administrator in the organization of the project called "Ruby Rockstars"
   And I follow "Import"
-  And I choose "Teambox"
+  And I choose "Crewmate"
   And I attach the file "spec/fixtures/teamboxdump_problem.json" to "teambox_data_import_data"
   And I press "Import data"
   When I select the following:
@@ -57,7 +57,7 @@ Scenario: Mislav imports another historic project
     | Test Test (@steve_testing)            |  Pablo Villalba (@pablo)   |
     | Card Test (@stevecardtest)            |  Gandalf Grey (@gandalf)   |
     | Stevie Hobs (@steve)                  |  Frodo Baggins (@frodo)    |
-    | Put all projects in this organization | Teambox Data               |
+    | Put all projects in this organization | Crewmate Data               |
   And I press "Import"
   Then I should see "Imported projects"
   And I should see "Hobo Pro"
@@ -66,7 +66,7 @@ Scenario: Mislav imports another historic project
   And @frodo should receive no emails
   And @gandalf should receive no emails
 
-Scenario: Mislav gets fed up of Basecamp and moves to Teambox
+Scenario: Mislav gets fed up of Basecamp and moves to Crewmate
   When I go to the your data page
   And I follow "Import"
   And I choose "Basecamp"
@@ -75,7 +75,7 @@ Scenario: Mislav gets fed up of Basecamp and moves to Teambox
   Then I should see "Frodo Baggins (@FrodoBaggins)"
   When I select the following:
     | Frodo Baggins                         |  Mislav Marohnić (@mislav) |
-    | Put all projects in this organization | Teambox Data               |
+    | Put all projects in this organization | Crewmate Data               |
   And I press "Import"
   Then I should see "Imported projects"
   And I should see "Widgets"
@@ -85,7 +85,7 @@ Scenario: Mislav gets fed up of Basecamp and moves to Teambox
 Scenario: Mislav gets confused and uploads the wrong dump
   When I go to the your data page
   And I follow "Import"
-  And I choose "Teambox"
+  And I choose "Crewmate"
   And I attach the file "spec/fixtures/campdump.xml" to "teambox_data_import_data"
   And I press "Import data"
   Then I should see "There was an error loading your import. Please try again."
@@ -94,7 +94,7 @@ Scenario: Mislav gets confused and uploads the wrong dump
 Scenario: Mislav forgets to map the data
   When I go to the your data page
   And I follow "Import"
-  And I choose "Teambox"
+  And I choose "Crewmate"
   And I attach the file "spec/fixtures/teamboxdump.json" to "teambox_data_import_data"
   And I press "Import data"
   Then I should see "Andrew Wiggin (@gandhi_1)"
@@ -108,7 +108,7 @@ Scenario: Mislav forgets to map the data
 Scenario: Mislav imports data with invalid records
   When I go to the your data page
   And I follow "Import"
-  And I choose "Teambox"
+  And I choose "Crewmate"
   And I attach the file "spec/fixtures/teamboxdump_invalid.json" to "teambox_data_import_data"
   And I press "Import data"
   Then I should see "Andrew Wiggin (@gandhi_1)"
@@ -120,7 +120,7 @@ Scenario: Mislav imports data with invalid records
     | Andrew Wiggin (@gandhi_2)             |  Mislav Marohnić (@mislav) |
     | Andrew Wiggin (@gandhi_3)             |  Mislav Marohnić (@mislav) |
     | Andrew Wiggin (@gandhi_4)             |  Mislav Marohnić (@mislav) |
-    | Put all projects in this organization | Teambox Data               |
+    | Put all projects in this organization | Crewmate Data               |
   And I press "Import"
   Then I should see "There were errors with the information you supplied!"
   And @mislav should receive 1 email

--- a/features/time_tracking.feature
+++ b/features/time_tracking.feature
@@ -4,21 +4,21 @@ Feature: When I view the time tracking reports globally
   Background:
     Given @mislav exists and is logged in
     And I am a participant in the organization called "ACME"
-    And I am a participant in the organization called "Teambox"
-    And there is a project called "Teambox Accounting"
+    And I am a participant in the organization called "Crewmate"
+    And there is a project called "Crewmate Accounting"
     And there is a project called "ACME Marketing"
-    And "mislav" is the owner of the project "Teambox Accounting"
+    And "mislav" is the owner of the project "Crewmate Accounting"
     And "mislav" is the owner of the project "ACME Marketing"
-    And the project "Teambox Accounting" belongs to "Teambox" organization
+    And the project "Crewmate Accounting" belongs to "Crewmate" organization
     And the project "ACME Marketing" belongs to "ACME" organization
     And the following task lists with associations exist:
       | name          | project            |
-      | Fake results  | Teambox Accounting |
+      | Fake results  | Crewmate Accounting |
       | Send spam     | ACME Marketing     |
     And the following tasks with hours exists:
       | name                                   | task_list    | project            | comment             | hours  |
-      | Calculate possible fake results        | Fake results | Teambox Accounting | Working on it...    | 1h 30m |
-      | Change numbers from last year books    | Fake results | Teambox Accounting | I got this          | 2h     |
+      | Calculate possible fake results        | Fake results | Crewmate Accounting | Working on it...    | 1h 30m |
+      | Change numbers from last year books    | Fake results | Crewmate Accounting | I got this          | 2h     |
       | Post on Digg and Hacker News           | Send spam    | ACME Marketing     | So easy             | 30m    |
       | Send a weekly newsletter               | Send spam    | ACME Marketing     | K is helping me     | 5h     |
 
@@ -30,7 +30,7 @@ Feature: When I view the time tracking reports globally
 
   Scenario: I can filter by organization
     When I go to time tracking
-    And I select "Teambox" from "hours_organization_filter_assigned"
+    And I select "Crewmate" from "hours_organization_filter_assigned"
     Then I should see "1h 30m"
     And I should not see "5h"
     And I should see "3h 30m"
@@ -41,7 +41,7 @@ Feature: When I view the time tracking reports globally
 
   Scenario: I can filter by project
     When I go to time tracking
-    And I select "Teambox Accounting" from "hours_project_filter_assigned"
+    And I select "Crewmate Accounting" from "hours_project_filter_assigned"
     Then I should see "1h 30m"
     And I should not see "5h"
     And I should see "3h 30m"

--- a/features/user_edit_settings.feature
+++ b/features/user_edit_settings.feature
@@ -1,6 +1,6 @@
 Feature: Edit user settings
   In order to save a ton of time
-  As a Teambox admin
+  As a Crewmate admin
   I want users to edit their own settings
 
   Background: 

--- a/features/user_profile.feature
+++ b/features/user_profile.feature
@@ -4,7 +4,7 @@ Feature: Showing users
     Given the following confirmed users exist
       | login  | email                 | first_name | last_name |
       | balint | balint.erdi@gmail.com | Balint     | Erdi      |
-      | pablo  | pablo@teambox.com     | Pablo      | Villalba  |
+      | pablo  | pablo@crewmate.org     | Pablo      | Villalba  |
     Given @mislav exists and is logged in
     And I am currently in the project ruby_rockstars
     And I go to project settings page

--- a/features/user_reset_password.feature
+++ b/features/user_reset_password.feature
@@ -7,7 +7,7 @@ Feature: Resetting passwords
   Background: 
     Given the following confirmed users exist
       | login | email             | first_name | last_name |
-      | pablo | pablo@teambox.com | Pablo      | Villalba  |
+      | pablo | pablo@crewmate.org | Pablo      | Villalba  |
 
   Scenario: I try resetting the password for a non existing user
     Given I am on the login page
@@ -28,7 +28,7 @@ Feature: Resetting passwords
     And "mislav@fuckingawesome.com" should receive an email
     When I open the email
     Then I should see "Hey, Mislav Marohnić!" in the email body
-    When I follow "Log into Teambox now!" in the email
+    When I follow "Log into Crewmate now!" in the email
     Then I should see "You can now reset your password"
     When I fill in "Password" with "thirstycups"
     And I fill in "Password confirmation" with "thirstycups"
@@ -55,7 +55,7 @@ Feature: Resetting passwords
     And I press "Send me a link to reset my password"
     And "mislav@fuckingawesome.com" should receive an email
     When I open the email
-    When I follow "Log into Teambox now!" in the email
+    When I follow "Log into Crewmate now!" in the email
     When I fill in "Password" with "thirstycups"
     And I fill in "Password confirmation" with "thirstycups"
     And I press "Reset my password"
@@ -65,10 +65,10 @@ Feature: Resetting passwords
   Scenario: Deleted user tries to reset password
     Given the user with login: "pablo" is deleted
     And I am on the forgot password page
-    When I fill in "Email" with "pablo@teambox.com"
+    When I fill in "Email" with "pablo@crewmate.org"
     And I press "Send me a link to reset my password"
     Then I should see "We can't find a user with that email"
-    And "pablo@teambox.com" should receive 0 emails
+    And "pablo@crewmate.org" should receive 0 emails
 
   Scenario: Deleted user tries to use a previously generated reset code
     Given the user with login: "pablo" has asked to reset his password

--- a/features/user_signup.feature
+++ b/features/user_signup.feature
@@ -16,7 +16,7 @@ Feature: Signing up
     And "mislav@fuckingawesome.com" should receive an email
     When I open the email
     Then I should see "Hey, Mislav Marohnić!" in the email body
-    When I follow "Log into Teambox now!" in the email
+    When I follow "Log into Crewmate now!" in the email
     Then I should see "Welcome"
 
   Scenario Outline: User tries to sign up with a reserved username


### PR DESCRIPTION
Not massively useful, but anything that clears the results fetched with grep is an improvement.
