### PR TITLE
fixed a bug where the Task List title would disappear when editing

### DIFF
--- a/app/views/task_lists/_title_edit_form.haml
+++ b/app/views/task_lists/_title_edit_form.haml
@@ -1,3 +1,3 @@
-- task_list_form_for(project,task_list) do |f|
+= task_list_form_for(project,task_list) do |f|
   = task_list_title_fields(f,project,task_list)
   = task_list_submit(project,task_list)


### PR DESCRIPTION
This fix refers to Issue 128. [Fixes #128]
