### PR TITLE
Issues resolved when installing on CentOS 7 minimal server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ teambox2
 config/teambox.yml
 config/crewmate.yml
 
+/.gem
+/bin

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ gem 'rack-ssl-enforcer', require: 'rack/ssl-enforcer'
 gem 'jammit'
 gem 'rake', '0.9.2'
 gem 'thin'
-
+gem 'iconv'
+gem 'json_pure'
 
 gem 'mysql2', '~> 0.2.0', group: 'mysql'
 # gem 'mysql', '~> 2.8.1', :require => nil, :group => 'mysql'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,12 +160,14 @@ GEM
     hpricot (0.8.6)
     i18n (0.5.0)
     icalendar (1.1.6)
+    iconv (1.0.4)
     innertube (1.0.2)
     jammit (0.6.6)
       cssmin (>= 1.0.3)
       jsmin (>= 1.0.1)
     jsmin (1.0.1)
     json (1.8.1)
+    json_pure (1.8.2)
     launchy (0.3.7)
       configuration (>= 0.0.5)
       rake (>= 0.8.1)
@@ -350,9 +352,11 @@ DEPENDENCIES
   hpricot (~> 0.8.2)
   i18n (= 0.5.0)
   icalendar (~> 1.1.3)
+  iconv
   immortal!
   jammit
   json
+  json_pure
   launchy (~> 0.3.7)
   libxml-ruby
   mysql2 (~> 0.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
 
   include AuthenticatedSystem
 
+  config.relative_url_root = ""
+
   before_filter :set_locale,
                 :rss_token,
                 :set_client,


### PR DESCRIPTION
Added iconv and json_pure as required gems, they were blowing up when installing (possibly the database bootstrap process). Also note that I had to modify /etc/my.cnf to remove STRICT_TRANS_TABLES from sql_mode, as apparently the way the db is configured depends on empty string defaults for text/blob. Also added a line in the application controller to set the relative_root_url to non-nil as it causes problems loading resources, see https://github.com/rails/rails/issues/9619
